### PR TITLE
Use browser's built in pdf previewer 

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ $ npm install --save hexo-pdf
 {% pdf http://7xov2f.com1.z0.glb.clouddn.com/bash_freshman.pdf %}
 ```
 
+or
+```
+{% pdf ./bash_freshman.pdf %}
+```
+
 ### Google drive
 ```
 {% pdf https://drive.google.com/file/d/0B6qSwdwPxPRdTEliX0dhQ2JfUEU/preview %}

--- a/reader.ejs
+++ b/reader.ejs
@@ -1,7 +1,7 @@
 <% if(type == 'normal') { %>
 
 	<div class="row">
-	  <iframe src="http://nagland.github.io/viewer/web/viewer.html?val=<%= src %>" style="width:100%; height:550px"></iframe>
+    <embed src="<%= src %>" width="100%" height="550" type="application/pdf">
 	</div>
 
 <% } else if (type == 'googledoc'){ %>


### PR DESCRIPTION
Use browser's built in pdf previewer so as to avoid previewer breaking when using hsts
closes #2 
and adds support for relative links