### PR TITLE
Update EJS dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "author": "SRK.Lyu <superalsrk@gmail.com> (http://stackbox.org)",
   "license": "MIT",
   "dependencies": {
-    "ejs": "^3.1.9"
+    "ejs": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^3.1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -15,6 +15,6 @@
   "author": "SRK.Lyu <superalsrk@gmail.com> (http://stackbox.org)",
   "license": "MIT",
   "dependencies": {
-    "ejs": "^1.0.0"
+    "ejs": "^3.1.9"
   }
 }


### PR DESCRIPTION
When I installed hexo-pdf, I got a warning that EJS version was deprecated. I updated from v. 1.0.0 to v. 3.1.9, and everything worked as it had before. Suggest updating dependency version for future users.